### PR TITLE
Updated amqplib version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "./node_modules/gulp/bin/gulp.js test"
   },
   "dependencies": {
-    "amqplib": "0.1.3",
+    "amqplib": "0.4.0",
     "debug": "2.1.3",
     "lodash": "3.7.0",
     "q": "1.2.0",


### PR DESCRIPTION
See this warning on latest node.js versions:

```
npm WARN engine amqplib@0.1.3: wanted: {"node":"0.8 || 0.9 || 0.10 || 0.11"} (current: {"node":"4.1.1","npm":"2.14.4"})
```

And apparently changes between 0.1.3 and 0.4.0 are not that large:

https://github.com/squaremo/amqp.node/blob/master/CHANGELOG.md