### PR TITLE
Adding rate limitations for emitting data messages (can be set from D…

### DIFF
--- a/lib/amqp.js
+++ b/lib/amqp.js
@@ -3,6 +3,7 @@ const amqplib = require('amqplib');
 const encryptor = require('./encryptor.js');
 const co = require('co');
 const _ = require('lodash');
+const rateLimit = require('function-rate-limit');
 
 const HEADER_ROUTING_KEY = 'x-eio-routing-key';
 const HEADER_ERROR_RESPONSE = 'x-eio-error-response';
@@ -10,6 +11,17 @@ const HEADER_ERROR_RESPONSE = 'x-eio-error-response';
 class Amqp {
     constructor(settings) {
         this.settings = settings;
+
+        const dataRateLimit = this.settings && this.settings.DATA_RATE_LIMIT
+            ? this.settings.DATA_RATE_LIMIT : 200;
+        const errorRateLimit = this.settings && this.settings.ERROR_RATE_LIMIT
+            ? this.settings.ERROR_RATE_LIMIT : 20;
+        const snapshotRateLimit = this.settings && this.settings.SNAPSHOT_RATE_LIMIT
+            ? this.settings.SNAPSHOT_RATE_LIMIT : 20;
+
+        this.sendData = rateLimit(dataRateLimit, 1000, this.sendDataUnlimited);
+        this.sendError = rateLimit(errorRateLimit, 1000, this.sendErrorUnlimited);
+        this.sendSnapshot = rateLimit(snapshotRateLimit, 1000, this.sendSnapshotUnlimited);
     }
 
     connect(uri) {
@@ -118,7 +130,7 @@ class Amqp {
         this.sendToExchange(settings.PUBLISH_MESSAGES_TO, routingKey, encryptedData, properties);
     }
 
-    sendData(data, properties) {
+    sendDataUnlimited(data, properties) {
         const settings = this.settings;
 
         const msgHeaders = data.headers || {};
@@ -140,7 +152,7 @@ class Amqp {
         this.prepareMessageAndSendToExchange(data, properties, routingKey);
     }
 
-    sendError(err, properties, originalMessageContent) {
+    sendErrorUnlimited(err, properties, originalMessageContent) {
         const settings = this.settings;
         const headers = properties.headers;
 
@@ -206,7 +218,7 @@ class Amqp {
         }
     }
 
-    sendSnapshot(data, properties) {
+    sendSnapshotUnlimited(data, properties) {
         const settings = this.settings;
         const exchange = settings.PUBLISH_MESSAGES_TO;
         const routingKey = settings.SNAPSHOT_ROUTING_KEY;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1811,6 +1811,11 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-rate-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-rate-limit/-/function-rate-limit-1.1.0.tgz",
+      "integrity": "sha1-7M3xr5GPyVnrZQkFhgPkYuN/1oM="
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "elasticio-sailor-nodejs",
   "description": "The official elastic.io library for bootstrapping and executing for Node.js connectors",
-  "version": "2.2.2",
+  "version": "2.2.3-dev.1",
   "main": "run.js",
   "scripts": {
     "lint": "./node_modules/.bin/eslint lib spec mocha_spec lib run.js runService.js",
@@ -20,6 +20,7 @@
     "co": "4.6.0",
     "debug": "3.1.0",
     "elasticio-rest-node": "1.2.2",
+    "function-rate-limit": "^1.1.0",
     "lodash": "4.17.4",
     "q": "1.4.1",
     "request-promise-native": "^1.0.5",


### PR DESCRIPTION
Resolving [this](https://github.com/elasticio/sailor-nodejs/issues/76) issue:
- Adding rate limitations for emitting data messages (can be set from DATA_RATE_LIMIT envar - 200/sec by default), error messages (can be set from ERROR_RATE_LIMIT envar - 20/sec by default) and snapshot messages (can be set from SNAPSHOT_RATE_LIMIT envar - 20/sec by default).