### PR TITLE
Add logger to init, startup, shutdown

### DIFF
--- a/lib/sailor.js
+++ b/lib/sailor.js
@@ -2,6 +2,8 @@ const ComponentReader = require('./component_reader.js').ComponentReader;
 const amqp = require('./amqp.js');
 const TaskExec = require('./executor.js').TaskExec;
 const log = require('./logging.js');
+const { ComponentLogger } = log;
+const { EventEmitter } = require('events');
 const _ = require('lodash');
 const Q = require('q');
 const cipher = require('./cipher.js');
@@ -147,9 +149,11 @@ class Sailor {
                 return Promise.resolve();
             }
             const cfg = _.cloneDeep(stepData.config) || {};
+            const callScope = new EventEmitter();
+            callScope.logger = new ComponentLogger();
             return new Promise((resolve, reject) => {
                 try {
-                    resolve(module[moduleFunction](cfg, data));
+                    resolve(module[moduleFunction].call(callScope, cfg, data));
                 } catch (e) {
                     reject(e);
                 }


### PR DESCRIPTION
https://github.com/elasticio/sailor-nodejs/issues/103

Makes the component logger part of the scope of functions `init`, `startup`, and `shutdown`.

Can test by installing this branch version of npm : `npm install elasticio/sailor-nodejs#add-logger-to-functions`